### PR TITLE
Update UA to GA4

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,9 +19,6 @@
 
       gtag('config', 'UA-78530187-19');
     </script>
-    <!-- TEST Google tag (gtag.js) -->
-     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P60KQVZ793"></script> <script>   window.dataLayer = window.dataLayer || [];   function gtag(){dataLayer.push(arguments);}   gtag('js', new Date());   gtag('config', 'G-P60KQVZ793'); </script>
-
     <!-- End Google Tag Manager -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -54,7 +51,7 @@
         "contributor": [
         {
           "@type": "Person",
-          "name": "Colleen Nell",
+          "name": "Cee Nell",
           "email": "cnell@usgs.gov",
           "affiliation": {
             "@context": "http://schema.org",

--- a/public/index.html
+++ b/public/index.html
@@ -1,24 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P60KQVZ793"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
-
-      gtag('config', 'G-P60KQVZ793');
-    </script>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-78530187-19"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
-
-      gtag('config', 'UA-78530187-19');
-    </script>
     <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/public/index.html
+++ b/public/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
   <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8B7JZL5B3T"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P60KQVZ793"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag('js', new Date());
 
-      gtag('config', 'G-8B7JZL5B3T');
+      gtag('config', 'G-P60KQVZ793');
     </script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-78530187-19"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,13 @@
 
       gtag('config', 'UA-78530187-19');
     </script>
-    <!-- End Google Tag Manager -->
+    <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-N69B8PH');</script>
+  <!-- End Google Tag Manager -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">


### PR DESCRIPTION
Update google analytics tag from UA to GA4. Including GTM tracking. This site had previously used UA and GA4. Now the two properties are connected. The original GA4 tag is retained in the analytics account for past data.