### PR TITLE
insert new GTM tag in place of old UA and GA4 tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,27 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8B7JZL5B3T"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
-
-      gtag('config', 'G-8B7JZL5B3T');
-    </script>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-78530187-19"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
-
-      gtag('config', 'UA-78530187-19');
-    </script>
-    <!-- TEST Google tag (gtag.js) -->
-     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P60KQVZ793"></script> <script>   window.dataLayer = window.dataLayer || [];   function gtag(){dataLayer.push(arguments);}   gtag('js', new Date());   gtag('config', 'G-P60KQVZ793'); </script>
-
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N69B8PH');</script>
     <!-- End Google Tag Manager -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -54,7 +39,7 @@
         "contributor": [
         {
           "@type": "Person",
-          "name": "Colleen Nell",
+          "name": "Cee Nell",
           "email": "cnell@usgs.gov",
           "affiliation": {
             "@context": "http://schema.org",
@@ -118,8 +103,8 @@
   <body>
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N69B8PH"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <!-- End Google Tag Manager (noscript) -->
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>
       <strong>We're sorry but this application doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ import { faFlickr } from '@fortawesome/free-brands-svg-icons'
 import { faYoutubeSquare } from '@fortawesome/free-brands-svg-icons'
 import { faInstagram } from "@fortawesome/free-brands-svg-icons";
 
-Vue.component('font-awesome-icon', FontAwesomeIcon);
+Vue.component('FontAwesomeIcon', FontAwesomeIcon);
 
 // social icons
 library.add(faTwitterSquare);

--- a/src/views/4Guidance/Guidance.vue
+++ b/src/views/4Guidance/Guidance.vue
@@ -43,7 +43,7 @@
     >
       <div class="flex-item">
         <picture>
-                   <source
+          <source
             srcset="@/assets/images/examples/Buffalo-Creek-Fan_400w.jpg 400w,
             @/assets/images/examples/Buffalo-Creek-Fan_800w.jpg 800w,
             @/assets/images/examples/Buffalo-Creek-Fan.jpg 1500w"
@@ -62,7 +62,7 @@
       </div>
       <div class="flex-item">
         <picture>
-                <source
+          <source
             srcset="@/assets/images/examples/Gibraltar-Reservoir_400w.jpg 400w,
             @/assets/images/examples/Gibraltar-Reservoir_800w.jpg 800w,
             @/assets/images/examples/Gibraltar-Reservoir.jpg 1500w"


### PR DESCRIPTION
This PR replaces the UA and GA4 tags with the GTM tag.  Changes to files other than `index.html` are from running lint.

The GTM container has been configured to point to the existing GA4 account.

Tags on [existing page](https://labs.waterdata.usgs.gov/visualizations/fire-hydro/index.html#/): 

![image](https://github.com/DOI-USGS/fire-hydro/assets/54007288/981028ef-32c7-4c3e-aa01-fef15ec45252)

Tags on updated page (previewed from local host):

![image](https://github.com/DOI-USGS/fire-hydro/assets/54007288/8576f688-a4d7-491d-bbe3-a5801ead1cf1)


Before making a pull request
----------------------------
First . . .
- [X] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [X] Chrome
- [ ] Safari
- [X] Edge
- [X] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
